### PR TITLE
feat(react-hook,card): integrate reat hook form in checkbox radio switch and create toggle card

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -2063,7 +2063,7 @@ packages:
       '@expo/rudder-sdk-node': 1.1.1
       '@expo/spawn-async': 1.7.2
       '@expo/xcpretty': 4.3.1
-      '@react-native/dev-middleware': 0.74.85
+      '@react-native/dev-middleware': 0.74.84
       '@urql/core': 2.3.6(graphql@15.8.0)
       '@urql/exchange-retry': 0.3.0(graphql@15.8.0)
       accepts: 1.3.8
@@ -2323,7 +2323,7 @@ packages:
       '@expo/config-types': 51.0.2
       '@expo/image-utils': 0.5.1
       '@expo/json-file': 8.3.3
-      '@react-native/normalize-colors': 0.74.85
+      '@react-native/normalize-colors': 0.74.84
       debug: 4.3.5
       expo-modules-autolinking: 1.11.1
       fs-extra: 9.1.0
@@ -2345,7 +2345,7 @@ packages:
       '@expo/config-types': 51.0.2
       '@expo/image-utils': 0.5.1
       '@expo/json-file': 8.3.3
-      '@react-native/normalize-colors': 0.74.85
+      '@react-native/normalize-colors': 0.74.84
       debug: 4.3.5
       expo-modules-autolinking: 1.11.1
       fs-extra: 9.1.0
@@ -3682,7 +3682,7 @@ packages:
     engines: {node: '>=18'}
     dependencies:
       '@isaacs/ttlcache': 1.4.1
-      '@react-native/debugger-frontend': 0.74.85
+      '@react-native/debugger-frontend': 0.74.84
       '@rnx-kit/chromium-edge-launcher': 1.0.0
       chrome-launcher: 0.15.2
       connect: 3.7.0
@@ -4494,7 +4494,7 @@ packages:
   /acorn-globals@7.0.1:
     resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
     dependencies:
-      acorn: 8.12.1
+      acorn: 8.12.0
       acorn-walk: 8.3.3
     dev: true
 
@@ -4510,8 +4510,7 @@ packages:
     resolution: {integrity: sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==}
     engines: {node: '>=0.4.0'}
     dependencies:
-      acorn: 8.12.1
-    dev: true
+      acorn: 8.12.0
 
   /acorn@8.12.0:
     resolution: {integrity: sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==}
@@ -5157,10 +5156,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001640
-      electron-to-chromium: 1.4.816
+      caniuse-lite: 1.0.30001639
+      electron-to-chromium: 1.4.815
       node-releases: 2.0.14
-      update-browserslist-db: 1.1.0(browserslist@4.23.1)
+      update-browserslist-db: 1.0.16(browserslist@4.23.1)
 
   /bs-logger@0.2.6:
     resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
@@ -6792,8 +6791,8 @@ packages:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.12.1
-      acorn-jsx: 5.3.2(acorn@8.12.1)
+      acorn: 8.12.0
+      acorn-jsx: 5.3.2(acorn@8.12.0)
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -7134,7 +7133,7 @@ packages:
     peerDependencies:
       expo: '*'
     dependencies:
-      '@react-native/normalize-colors': 0.74.85
+      '@react-native/normalize-colors': 0.74.84
       debug: 4.3.5
       expo: 51.0.8(@babel/core@7.24.5)(@babel/preset-env@7.24.7)
     transitivePeerDependencies:
@@ -9259,7 +9258,7 @@ packages:
         optional: true
     dependencies:
       abab: 2.0.6
-      acorn: 8.12.1
+      acorn: 8.12.0
       acorn-globals: 7.0.1
       cssom: 0.5.0
       cssstyle: 2.3.0
@@ -11701,7 +11700,7 @@ packages:
       react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.24.7
-      '@react-native/normalize-colors': 0.74.85
+      '@react-native/normalize-colors': 0.74.84
       fbjs: 3.0.5
       inline-style-prefixer: 6.0.4
       memoize-one: 6.0.0
@@ -12968,7 +12967,7 @@ packages:
     hasBin: true
     dependencies:
       '@jridgewell/source-map': 0.3.6
-      acorn: 8.12.1
+      acorn: 8.12.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -13161,7 +13160,7 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 20.5.1
-      acorn: 8.12.1
+      acorn: 8.12.0
       acorn-walk: 8.3.3
       arg: 4.1.3
       create-require: 1.1.1

--- a/src/shared/components/checkbox-input.tsx
+++ b/src/shared/components/checkbox-input.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import type { Control, FieldValues, Path } from 'react-hook-form';
+import type {
+  Control,
+  FieldValues,
+  Path,
+  RegisterOptions,
+} from 'react-hook-form';
 import { useController } from 'react-hook-form';
 
 import { Checkbox } from './checkbox';
@@ -9,7 +14,7 @@ type Props<T extends FieldValues> = {
   label: string;
   name: Path<T>;
   control: Control<T>;
-  rules?: any;
+  rules?: RegisterOptions;
 };
 export const CheckboxInput = <T extends FieldValues>(props: Props<T>) => {
   const { name, control, rules, label, accessibilityLabel, className } = props;

--- a/src/shared/components/checkbox-input.tsx
+++ b/src/shared/components/checkbox-input.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import type {
-  Control,
-  FieldValues,
-  Path,
-  RegisterOptions,
+import {
+  type Control,
+  type FieldValues,
+  type Path,
+  type RegisterOptions,
+  useController,
 } from 'react-hook-form';
-import { useController } from 'react-hook-form';
 
 import { Checkbox } from './checkbox';
 type Props<T extends FieldValues> = {

--- a/src/shared/components/checkbox-input.tsx
+++ b/src/shared/components/checkbox-input.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import type { Control, FieldValues, Path } from 'react-hook-form';
+import { useController } from 'react-hook-form';
+
+import { Checkbox } from './checkbox';
+type Props<T extends FieldValues> = {
+  className?: string;
+  accessibilityLabel: string;
+  label: string;
+  name: Path<T>;
+  control: Control<T>;
+  rules?: any;
+};
+export const CheckboxInput = <T extends FieldValues>(props: Props<T>) => {
+  const { name, control, rules, label, accessibilityLabel, className } = props;
+
+  const { field, fieldState } = useController({ control, name, rules });
+
+  return (
+    <Checkbox.Root
+      checked={field.value}
+      onChange={field.onChange}
+      error={fieldState.error?.message}
+      accessibilityLabel={accessibilityLabel}
+      className={`${className} pb-2`}
+    >
+      <Checkbox.Icon checked={field.value} />
+      <Checkbox.Label text={label} />
+    </Checkbox.Root>
+  );
+};

--- a/src/shared/components/checkbox.tsx
+++ b/src/shared/components/checkbox.tsx
@@ -1,8 +1,8 @@
 import { MotiView } from 'moti';
 import React, { useCallback } from 'react';
-import { Pressable, type PressableProps, View } from 'react-native';
 import Svg, { Path } from 'react-native-svg';
 
+import { Pressable, type PressableProps, View } from '@/shared/components';
 import colors from '@/theme/colors';
 
 import { Text } from './text';

--- a/src/shared/components/checkbox.tsx
+++ b/src/shared/components/checkbox.tsx
@@ -1,6 +1,6 @@
 import { MotiView } from 'moti';
 import React, { useCallback } from 'react';
-import { Pressable, type PressableProps } from 'react-native';
+import { Pressable, type PressableProps, View } from 'react-native';
 import Svg, { Path } from 'react-native-svg';
 
 import colors from '@/theme/colors';
@@ -12,6 +12,7 @@ export interface RootProps extends Omit<PressableProps, 'onPress'> {
   checked?: boolean;
   className?: string;
   accessibilityLabel: string;
+  error?: string;
 }
 
 export type IconProps = {
@@ -24,6 +25,7 @@ export const Root = ({
   onChange,
   disabled,
   className = '',
+  error,
   ...props
 }: RootProps) => {
   const handleChange = useCallback(() => {
@@ -31,17 +33,24 @@ export const Root = ({
   }, [onChange, checked]);
 
   return (
-    <Pressable
-      onPress={handleChange}
-      className={`flex-row items-center ${className} ${
-        disabled ? 'opacity-50' : ''
-      }`}
-      accessibilityState={{ checked }}
-      disabled={disabled}
-      {...props}
-    >
-      {children}
-    </Pressable>
+    <View className="flex-1">
+      <Pressable
+        onPress={handleChange}
+        className={`flex-row items-center ${className} ${
+          disabled ? 'opacity-50' : ''
+        }`}
+        accessibilityState={{ checked }}
+        disabled={disabled}
+        {...props}
+      >
+        {children}
+      </Pressable>
+      {error && (
+        <Text className="text-danger-400 dark:text-danger-600 text-sm">
+          {error}
+        </Text>
+      )}
+    </View>
   );
 };
 

--- a/src/shared/components/controlled-input.tsx
+++ b/src/shared/components/controlled-input.tsx
@@ -1,16 +1,15 @@
 import * as React from 'react';
-import type {
-  Control,
-  FieldValues,
-  Path,
-  RegisterOptions,
+import {
+  type Control,
+  type FieldValues,
+  type Path,
+  type RegisterOptions,
+  useController,
 } from 'react-hook-form';
-import { useController } from 'react-hook-form';
 
 import type { TxKeyPath } from '@/core';
 
-import type { NInputProps } from './input';
-import { Input } from './input';
+import { Input, type NInputProps } from './input';
 
 type TRule = Omit<
   RegisterOptions,

--- a/src/shared/components/index.tsx
+++ b/src/shared/components/index.tsx
@@ -28,6 +28,7 @@ export {
   KeyboardAvoidingView,
   Platform,
   Pressable,
+  type PressableProps,
   ScrollView,
   TouchableOpacity,
   View,

--- a/src/shared/components/index.tsx
+++ b/src/shared/components/index.tsx
@@ -4,6 +4,7 @@ import Svg from 'react-native-svg';
 export { default as colors } from '../../theme/colors';
 export * from './button';
 export * from './checkbox';
+export * from './checkbox-input';
 export * from './controlled-input';
 export * from './focus-aware-status-bar';
 export * from './image';
@@ -13,9 +14,12 @@ export * from './list';
 export * from './modal';
 export * from './progress-bar';
 export * from './radio';
+export * from './radio-input';
 export * from './select';
 export * from './switch';
+export * from './switch-input';
 export * from './text';
+export * from './toggle-card';
 export * from './utils';
 
 // export base components from react-native

--- a/src/shared/components/radio-input.tsx
+++ b/src/shared/components/radio-input.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import type { Control, FieldValues, Path } from 'react-hook-form';
+import { useController } from 'react-hook-form';
+
+import { Radio } from './radio';
+type Props<T extends FieldValues> = {
+  className?: string;
+  accessibilityLabel: string;
+  label: string;
+  name: Path<T>;
+  control: Control<T>;
+  rules?: any; // Adjust the type according to your validation rules
+};
+export const RadioInput = <T extends FieldValues>(props: Props<T>) => {
+  const { name, control, rules, label, accessibilityLabel, className } = props;
+
+  const { field, fieldState } = useController({ control, name, rules });
+
+  return (
+    <Radio.Root
+      checked={field.value}
+      onChange={field.onChange}
+      error={fieldState.error?.message}
+      accessibilityLabel={accessibilityLabel}
+      className={`${className} pb-2`}
+    >
+      <Radio.Icon checked={field.value} />
+      <Radio.Label text={label} />
+    </Radio.Root>
+  );
+};

--- a/src/shared/components/radio-input.tsx
+++ b/src/shared/components/radio-input.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import type { Control, FieldValues, Path } from 'react-hook-form';
+import type {
+  Control,
+  FieldValues,
+  Path,
+  RegisterOptions,
+} from 'react-hook-form';
 import { useController } from 'react-hook-form';
 
 import { Radio } from './radio';
@@ -9,7 +14,7 @@ type Props<T extends FieldValues> = {
   label: string;
   name: Path<T>;
   control: Control<T>;
-  rules?: any; // Adjust the type according to your validation rules
+  rules?: RegisterOptions; // Adjust the type according to your validation rules
 };
 export const RadioInput = <T extends FieldValues>(props: Props<T>) => {
   const { name, control, rules, label, accessibilityLabel, className } = props;

--- a/src/shared/components/radio-input.tsx
+++ b/src/shared/components/radio-input.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import type {
-  Control,
-  FieldValues,
-  Path,
-  RegisterOptions,
+import {
+  type Control,
+  type FieldValues,
+  type Path,
+  type RegisterOptions,
+  useController,
 } from 'react-hook-form';
-import { useController } from 'react-hook-form';
 
 import { Radio } from './radio';
 type Props<T extends FieldValues> = {

--- a/src/shared/components/radio.tsx
+++ b/src/shared/components/radio.tsx
@@ -1,12 +1,13 @@
 import { MotiView } from 'moti';
 import React from 'react';
 
+import {
+  type IconProps,
+  Root,
+  type RootProps,
+  Text,
+} from '@/shared/components';
 import colors from '@/theme/colors';
-
-import type { IconProps, RootProps } from './checkbox';
-import { Root } from './checkbox';
-import { Text } from './text';
-
 type LabelProps = {
   text: string;
   className?: string;

--- a/src/shared/components/select.tsx
+++ b/src/shared/components/select.tsx
@@ -6,13 +6,13 @@ import { FlashList } from '@shopify/flash-list';
 import * as React from 'react';
 import type { FieldValues } from 'react-hook-form';
 import { useController } from 'react-hook-form';
-import { Platform, TouchableOpacity, View } from 'react-native';
-import { Pressable, type PressableProps } from 'react-native';
 import type { SvgProps } from 'react-native-svg';
 import Svg, { Path } from 'react-native-svg';
 import { tv } from 'tailwind-variants';
 
 import { CaretDown } from '@/assets/icons';
+import { Platform, TouchableOpacity, View } from '@/shared/components';
+import { Pressable, type PressableProps } from '@/shared/components';
 import colors from '@/theme/colors';
 
 import type { InputControllerType } from './controlled-input';

--- a/src/shared/components/select.tsx
+++ b/src/shared/components/select.tsx
@@ -4,20 +4,22 @@ import {
 } from '@gorhom/bottom-sheet';
 import { FlashList } from '@shopify/flash-list';
 import * as React from 'react';
-import type { FieldValues } from 'react-hook-form';
-import { useController } from 'react-hook-form';
-import type { SvgProps } from 'react-native-svg';
-import Svg, { Path } from 'react-native-svg';
+import { type FieldValues, useController } from 'react-hook-form';
+import Svg, { Path, type SvgProps } from 'react-native-svg';
 import { tv } from 'tailwind-variants';
 
 import { CaretDown } from '@/assets/icons';
-import { Platform, TouchableOpacity, View } from '@/shared/components';
-import { Pressable, type PressableProps } from '@/shared/components';
+import {
+  Platform,
+  Pressable,
+  type PressableProps,
+  TouchableOpacity,
+  View,
+} from '@/shared/components';
 import colors from '@/theme/colors';
 
 import type { InputControllerType } from './controlled-input';
-import { useModal } from './modal';
-import { Modal } from './modal';
+import { Modal, useModal } from './modal';
 import { Text } from './text';
 
 const selectTv = tv({

--- a/src/shared/components/switch-input.tsx
+++ b/src/shared/components/switch-input.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import type { Control, FieldValues, Path } from 'react-hook-form';
+import type {
+  Control,
+  FieldValues,
+  Path,
+  RegisterOptions,
+} from 'react-hook-form';
 import { useController } from 'react-hook-form';
 
 import { Switch } from './switch';
@@ -9,7 +14,7 @@ type Props<T extends FieldValues> = {
   label: string;
   name: Path<T>;
   control: Control<T>;
-  rules?: any; // Adjust the type according to your validation rules
+  rules?: RegisterOptions; // Adjust the type according to your validation rules
 };
 export const SwitchInput = <T extends FieldValues>(props: Props<T>) => {
   const { name, control, rules, label, accessibilityLabel, className } = props;

--- a/src/shared/components/switch-input.tsx
+++ b/src/shared/components/switch-input.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import type {
-  Control,
-  FieldValues,
-  Path,
-  RegisterOptions,
+import {
+  type Control,
+  type FieldValues,
+  type Path,
+  type RegisterOptions,
+  useController,
 } from 'react-hook-form';
-import { useController } from 'react-hook-form';
 
 import { Switch } from './switch';
 type Props<T extends FieldValues> = {

--- a/src/shared/components/switch-input.tsx
+++ b/src/shared/components/switch-input.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import type { Control, FieldValues, Path } from 'react-hook-form';
+import { useController } from 'react-hook-form';
+
+import { Switch } from './switch';
+type Props<T extends FieldValues> = {
+  className?: string;
+  accessibilityLabel: string;
+  label: string;
+  name: Path<T>;
+  control: Control<T>;
+  rules?: any; // Adjust the type according to your validation rules
+};
+export const SwitchInput = <T extends FieldValues>(props: Props<T>) => {
+  const { name, control, rules, label, accessibilityLabel, className } = props;
+
+  const { field, fieldState } = useController({ control, name, rules });
+
+  return (
+    <Switch.Root
+      checked={field.value}
+      onChange={field.onChange}
+      error={fieldState.error?.message}
+      accessibilityLabel={accessibilityLabel}
+      className={`${className} pb-2`}
+    >
+      <Switch.Icon checked={field.value} />
+      <Switch.Label text={label} />
+    </Switch.Root>
+  );
+};

--- a/src/shared/components/switch.tsx
+++ b/src/shared/components/switch.tsx
@@ -4,8 +4,7 @@ import { I18nManager, View } from 'react-native';
 
 import colors from '@/theme/colors';
 
-import type { IconProps, RootProps } from './checkbox';
-import { Root } from './checkbox';
+import { type IconProps, Root, type RootProps } from './checkbox';
 import { Text } from './text';
 
 type LabelProps = {

--- a/src/shared/components/toggle-card.tsx
+++ b/src/shared/components/toggle-card.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import type { Control, FieldValues, Path } from 'react-hook-form';
+import type {
+  Control,
+  FieldValues,
+  Path,
+  RegisterOptions,
+} from 'react-hook-form';
 import { useController } from 'react-hook-form';
 import { Pressable } from 'react-native';
 
@@ -14,7 +19,7 @@ type CardProps<T extends FieldValues> = {
   svgComponent?: React.ComponentType;
   name: Path<T>;
   control: Control<T>;
-  rules?: any; // Adjust the type according to your validation rules
+  rules?: RegisterOptions; // Adjust the type according to your validation rules
 };
 
 export const ToggleCard = <T extends FieldValues>({

--- a/src/shared/components/toggle-card.tsx
+++ b/src/shared/components/toggle-card.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import type { Control, FieldValues, Path } from 'react-hook-form';
+import { useController } from 'react-hook-form';
+import { Pressable } from 'react-native';
+
+import { Image } from './image';
+import { Text } from './text';
+
+type CardProps<T extends FieldValues> = {
+  title?: string;
+  image?: string;
+  className?: string;
+  classNameText?: string;
+  svgComponent?: React.ComponentType;
+  name: Path<T>;
+  control: Control<T>;
+  rules?: any; // Adjust the type according to your validation rules
+};
+
+export const ToggleCard = <T extends FieldValues>({
+  title,
+  image,
+  className,
+  classNameText,
+  svgComponent: SvgComponent,
+  name,
+  control,
+  rules,
+  ...props
+}: CardProps<T>) => {
+  const { field, fieldState } = useController({ control, name, rules });
+
+  const handlePress = () => {
+    field.onChange(!field.value);
+  };
+  return (
+    <>
+      <Pressable
+        onPress={handlePress}
+        className={`${className}  flex-1 items-center justify-center self-center border-[0.5px] p-4 ${
+          field.value ? `border-primary` : 'border-borderColor'
+        } mb-7`}
+        {...props}
+      >
+        {SvgComponent ? (
+          <SvgComponent />
+        ) : (
+          <Image
+            className="h-1/2 w-1/2 overflow-hidden rounded-2xl"
+            source={{
+              uri: image,
+            }}
+          />
+        )}
+        <Text className={`${classNameText} text-center `}>{title}</Text>
+      </Pressable>
+      {fieldState.error?.message && (
+        <Text className="text-danger-400 dark:text-danger-600 text-sm">
+          {fieldState.error?.message}
+        </Text>
+      )}
+    </>
+  );
+};

--- a/src/shared/components/toggle-card.tsx
+++ b/src/shared/components/toggle-card.tsx
@@ -1,15 +1,13 @@
 import * as React from 'react';
-import type {
-  Control,
-  FieldValues,
-  Path,
-  RegisterOptions,
+import {
+  type Control,
+  type FieldValues,
+  type Path,
+  type RegisterOptions,
+  useController,
 } from 'react-hook-form';
-import { useController } from 'react-hook-form';
-import { Pressable } from 'react-native';
 
-import { Image } from './image';
-import { Text } from './text';
+import { Image, Pressable, Text } from '@/shared/components';
 
 type CardProps<T extends FieldValues> = {
   title?: string;


### PR DESCRIPTION

## What does this do?

Integrates React Hook Form with checkboxes, radio buttons, switches, and creates a toggle card. 
## Why did you do this?

To improve form handling and validation in the application by leveraging React Hook Form's capabilities for better state management and performance.
