### PR TITLE
feat(react-hook-form setup): centralize react hook form using customHook

### DIFF
--- a/src/app/(architect)/(public)/login.tsx
+++ b/src/app/(architect)/(public)/login.tsx
@@ -1,25 +1,16 @@
-import { useRouter } from 'expo-router';
 import React from 'react';
 
-import { useAuth } from '@/core';
 import { useSoftKeyboardEffect } from '@/core/keyboard';
 import LoginShared from '@/modules/login/login';
-import type { LoginFormProps } from '@/modules/login/login-form';
 import { FocusAwareStatusBar } from '@/shared/components';
 
 export default function Login() {
-  const router = useRouter();
-  const signIn = useAuth.use.signIn();
   useSoftKeyboardEffect();
 
-  const onSubmit: LoginFormProps['onSubmit'] = () => {
-    signIn({ access: 'access-token', refresh: 'refresh-token' });
-    router.push('/(architect)/(private)');
-  };
   return (
     <>
       <FocusAwareStatusBar />
-      <LoginShared onSubmit={onSubmit} />
+      <LoginShared />
     </>
   );
 }

--- a/src/modules/login/login-form.tsx
+++ b/src/modules/login/login-form.tsx
@@ -1,37 +1,36 @@
-import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'expo-router';
 import React, { useState } from 'react';
 import type { SubmitHandler } from 'react-hook-form';
-import { useForm } from 'react-hook-form';
 import { View } from 'react-native';
-import * as z from 'zod';
+import type * as z from 'zod';
 
-import { translate } from '@/core';
+import { translate, useAuth } from '@/core';
 import { Checkbox, ControlledInput, Text } from '@/shared/components';
+import useCustomForm from '@/shared/hooks/use-custom-form';
+import { LoginFormSchema } from '@/validations';
 
 import { Container } from '../shared';
 import LoginButton from '../shared/login-button';
 
-const schema = z.object({
-  email: z
-    .string({
-      required_error: 'Email is required',
-    })
-    .email('Invalid email format'),
-  password: z
-    .string({
-      required_error: 'Password is required',
-    })
-    .min(6, 'Password must be at least 6 characters'),
-});
-export type FormType = z.infer<typeof schema>;
+export type LoginFormType = z.infer<typeof LoginFormSchema>;
 export type LoginFormProps = {
-  onSubmit?: SubmitHandler<FormType>;
+  onSubmit?: SubmitHandler<LoginFormType>;
 };
-export const LoginForm = ({ onSubmit = () => {} }: LoginFormProps) => {
-  const { handleSubmit, control } = useForm<FormType>({
-    resolver: zodResolver(schema),
-  });
+
+export const LoginForm = ({ onSubmit }: LoginFormProps) => {
+  const { handleSubmit, control } = useCustomForm(LoginFormSchema);
+  const router = useRouter();
+  const signIn = useAuth.use.signIn();
   const [checked, setChecked] = useState(true);
+
+  const handleFormSubmit: SubmitHandler<LoginFormType> = (data) => {
+    signIn({ access: 'access-token', refresh: 'refresh-token' });
+    router.push('/(architect)/(private)');
+    if (onSubmit) {
+      onSubmit(data);
+    }
+  };
+
   return (
     <View className="flex w-full justify-center ">
       <ControlledInput
@@ -56,14 +55,14 @@ export const LoginForm = ({ onSubmit = () => {} }: LoginFormProps) => {
           accessibilityLabel="Se souvenir de moi"
           label={translate('login.souvenir')}
         />
-        <Text className={`font-lato text-xs font-semibold text-primary `}>
+        <Text className="font-lato text-xs font-semibold text-primary ">
           {translate('login.mdpOublier')}
         </Text>
       </Container>
       <LoginButton
         type="button"
         label={translate('login.connectBtn')}
-        loginFunction={handleSubmit(onSubmit)}
+        loginFunction={handleSubmit(handleFormSubmit)}
         radius="rounded-lg"
         width="w-full"
         height="h-12"

--- a/src/modules/login/login.tsx
+++ b/src/modules/login/login.tsx
@@ -1,15 +1,11 @@
 import React from 'react';
-import type { SubmitHandler } from 'react-hook-form';
 import { KeyboardAvoidingView, Platform, ScrollView } from 'react-native';
 
 import { LoginHeader, Welcome } from '../Components';
 import { AuthFooter, Conditions, Container } from '../shared';
-import type { FormType } from './login-form';
 import { LoginForm } from './login-form';
-export type LoginFormProps = {
-  onSubmit?: SubmitHandler<FormType>;
-};
-export default function LoginShared({ onSubmit = () => {} }: LoginFormProps) {
+
+export default function LoginShared() {
   return (
     <KeyboardAvoidingView
       behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
@@ -19,7 +15,7 @@ export default function LoginShared({ onSubmit = () => {} }: LoginFormProps) {
       <ScrollView>
         <Container style="flex-1 items-start justify-start w-full px-8 py-10 gap-5 ">
           <Welcome />
-          <LoginForm onSubmit={onSubmit} />
+          <LoginForm />
           <Conditions />
           <AuthFooter />
         </Container>

--- a/src/modules/reset-password/reset-form-email.tsx
+++ b/src/modules/reset-password/reset-form-email.tsx
@@ -1,24 +1,22 @@
-import { zodResolver } from '@hookform/resolvers/zod';
 import React from 'react';
 import type { SubmitHandler } from 'react-hook-form';
-import { useForm } from 'react-hook-form';
 import type * as z from 'zod';
 
 import { Button, ControlledInput, View } from '@/shared/components';
+import useCustomForm from '@/shared/hooks/use-custom-form';
 import { translate } from '@/translations/i18n';
 import { EmailSchema } from '@/validations';
 
-export type FormType = z.infer<typeof EmailSchema>;
+type EmailFormType = z.infer<typeof EmailSchema>;
 
-export type ResetFormProps = {
-  onSubmit?: SubmitHandler<FormType>;
+type ResetFormProps = {
+  onSubmit?: SubmitHandler<EmailFormType>;
 };
 export default function ResetFormEmail({
   onSubmit = () => {},
 }: ResetFormProps) {
-  const { handleSubmit, control, formState } = useForm<FormType>({
-    resolver: zodResolver(EmailSchema),
-  });
+  const { handleSubmit, control, form } = useCustomForm(EmailSchema);
+
   return (
     <View className="flex-1">
       <ControlledInput
@@ -32,7 +30,7 @@ export default function ResetFormEmail({
         label={translate('resetpass.reset')}
         onPress={handleSubmit(onSubmit)}
         className="h-12 rounded-md"
-        disabled={!formState.isValid}
+        disabled={!form.formState.isValid}
       />
     </View>
   );

--- a/src/modules/reset-password/reset-form-password.tsx
+++ b/src/modules/reset-password/reset-form-password.tsx
@@ -1,28 +1,26 @@
-import { zodResolver } from '@hookform/resolvers/zod';
 import React from 'react';
 import type { SubmitHandler } from 'react-hook-form';
-import { useForm } from 'react-hook-form';
 import type * as z from 'zod';
 
 import { Button, ControlledInput, Text, View } from '@/shared/components';
+import useCustomForm from '@/shared/hooks/use-custom-form';
 import type { TxKeyPath } from '@/translations/i18n';
 import { translate } from '@/translations/i18n';
 import { PasswordSchema } from '@/validations';
 
 import PasswordRequirementItem from './password-requirement-item';
 
-export type FormType = z.infer<typeof PasswordSchema>;
+type ResetFormType = z.infer<typeof PasswordSchema>;
 
-export type ResetFormPasswordProps = {
-  onSubmit?: SubmitHandler<FormType>;
+type ResetFormPasswordProps = {
+  onSubmit?: SubmitHandler<ResetFormType>;
 };
 export default function ResetFormPassword({
   onSubmit = () => {},
 }: ResetFormPasswordProps) {
-  const { handleSubmit, control, watch, formState } = useForm<FormType>({
-    resolver: zodResolver(PasswordSchema),
-  });
-  const password = watch('password');
+  const { handleSubmit, control, form } = useCustomForm(PasswordSchema);
+
+  const password = form.watch('password');
 
   const passwordRequirements: { isValid: boolean; message: TxKeyPath }[] = [
     {
@@ -71,7 +69,7 @@ export default function ResetFormPassword({
         label={translate('resetpass.reset')}
         onPress={handleSubmit(onSubmit)}
         className="h-12 rounded-md"
-        disabled={!formState.isValid}
+        disabled={!form.formState.isValid}
       />
     </View>
   );

--- a/src/modules/reset-password/verification-code.tsx
+++ b/src/modules/reset-password/verification-code.tsx
@@ -1,26 +1,24 @@
-import { zodResolver } from '@hookform/resolvers/zod';
 import React from 'react';
 import type { SubmitHandler } from 'react-hook-form';
-import { useForm } from 'react-hook-form';
 import type * as z from 'zod';
 
 import { Button, Text, TouchableOpacity, View } from '@/shared/components';
+import useCustomForm from '@/shared/hooks/use-custom-form';
 import { translate } from '@/translations/i18n';
 import { OTPSchema } from '@/validations';
 
 import { OTPInput } from './otp-input';
 
-export type FormType = z.infer<typeof OTPSchema>;
+type OTPFormType = z.infer<typeof OTPSchema>;
 
-export type ResetFormProps = {
-  onSubmit?: SubmitHandler<FormType>;
+type ResetFormProps = {
+  onSubmit?: SubmitHandler<OTPFormType>;
 };
 export default function VerificationCode({
   onSubmit = () => {},
 }: ResetFormProps) {
-  const { control, handleSubmit } = useForm<FormType>({
-    resolver: zodResolver(OTPSchema),
-  });
+  const { control, handleSubmit } = useCustomForm(OTPSchema);
+
   return (
     <View className="w-full flex-1 items-center justify-center">
       <View className="my-8 w-11/12 flex-1 ">

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -1,2 +1,4 @@
+export * from './use-custom-form';
 export * from './use-is-first-time';
 export * from './use-selected-theme';
+// export * from './use-toggle';

--- a/src/shared/hooks/use-custom-form.tsx
+++ b/src/shared/hooks/use-custom-form.tsx
@@ -1,0 +1,27 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import type { z, ZodType } from 'zod';
+const useCustomForm = <T extends ZodType<any, any>>(
+  schema: T,
+  defaultValues?: any
+) => {
+  type FormData = z.infer<typeof schema>;
+  const form = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: defaultValues,
+  });
+  const {
+    handleSubmit,
+    control,
+    formState: { errors },
+    setValue,
+  } = form;
+  return {
+    form,
+    handleSubmit,
+    control,
+    errors,
+    setValue,
+  };
+};
+export default useCustomForm;

--- a/src/validations/shared/shared-schema.tsx
+++ b/src/validations/shared/shared-schema.tsx
@@ -31,7 +31,7 @@ export const PasswordSchema = z.object({
 
 export const LoginFormSchema = z.object({
   email: emailValidation,
-  password: requiredValidation,
+  password: passwordValidation,
 });
 
 export const OTPSchema = z.object({


### PR DESCRIPTION
## What does this do?

This sets up React Hook Form using a custom hook to make the library more flexible, reusable, and centralized.

## Why did you do this?

I made these changes to enhance the flexibility and reusability of the form handling logic, allowing for a more centralized approach to managing form states and validations. This ensures that the form logic can be easily maintained and updated across different parts of the application.

## Who/what does this impact?

This change affects all components that utilize forms within the application. By centralizing the form logic, it minimizes redundancy and ensures consistency in form handling across the application. Developers working on these components should be aware of this change and may need to adjust their code to integrate with the new custom hook.

## How did you test this?

I tested this change by implementing the custom hook in various form components (login form, reset password form) and verifying that they function correctly.